### PR TITLE
Consistently use decimal file units

### DIFF
--- a/app/src/main/java/mega/privacy/android/app/utils/Util.java
+++ b/app/src/main/java/mega/privacy/android/app/utils/Util.java
@@ -518,16 +518,16 @@ public class Util {
 		String sizeString = "";
 		DecimalFormat decf = new DecimalFormat("###.##");
 
-		float KB = 1024;
-		float MB = KB * 1024;
-		float GB = MB * 1024;
-		float TB = GB * 1024;
+		float kB = 1000;
+		float MB = kB * 1000;
+		float GB = MB * 1000;
+		float TB = GB * 1000;
 		
-		if (size < KB){
+		if (size < kB){
 			sizeString = size + " B";
 		}
 		else if (size < MB){
-			sizeString = decf.format(size/KB) + " KB";
+			sizeString = decf.format(size/kB) + " kB";
 		}
 		else if (size < GB){
 			sizeString = decf.format(size/MB) + " MB";


### PR DESCRIPTION
Right now the File Info dialog uses decimal units (like the rest of the OS), and every other view in the app uses binary units. This pull request changes it so that the app uses decimal units (like the rest of the OS) everywhere.