### PR TITLE
Add missing dependencies instructions to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,6 +13,9 @@ This document will guide you to build the application on a Linux machine with An
 
 * [Android NDK](http://developer.android.com/intl/es/ndk/downloads/index.html)
 
+### Install missing dependencies
+* For Debian-based distro: ``` sudo apt install swig cmake libtool libncurses5 ```
+
 ### Build & Run the application
 
 * Get the source code.


### PR DESCRIPTION
Readme doesn't specify that some dependencies are required to run build.sh, which could fail without errors and confuse the person who is trying to compile (for example see #67).
With this PR I'm adding to the Readme the dependencies that were missing on my newly installed Debian 10.04 distro. I didn't checked all dependencies really needed, but I think this could be a starting point.