### PR TITLE
Rearrange libraries

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,12 +45,12 @@ android {
         versionName "$rootProject.appVersion ($rootProject.versionCode)"
 
         multiDexEnabled true
-        ndk.abiFilters 'armeabi-v7a','x86', 'x86_64', 'arm64-v8a'
+        ndk.abiFilters 'armeabi-v7a', 'x86', 'x86_64', 'arm64-v8a'
 
-        buildConfigField ("String", "USER_AGENT", "\"MEGAAndroid/${appVersion}_${versionCode}\"")
-        resValue ("string", "app_version", "\"${versionName}\"")
-        resValue ("string", "sdk_version", "\"${getSdkGitHash()}\"")
-        resValue ("string", "karere_version", "\"${getKarereGitHash()}\"")
+        buildConfigField("String", "USER_AGENT", "\"MEGAAndroid/${appVersion}_${versionCode}\"")
+        resValue("string", "app_version", "\"${versionName}\"")
+        resValue("string", "sdk_version", "\"${getSdkGitHash()}\"")
+        resValue("string", "karere_version", "\"${getKarereGitHash()}\"")
     }
 
     sourceSets.main {
@@ -60,7 +60,8 @@ android {
             exclude '**/MegaApiSwing.java'
         }
         jni.srcDirs = [] //disable automatic ndk-build
-        jniLibs.srcDir 'src/main/libs' // This is not necessary unless you have precompiled libraries in your project.
+        jniLibs.srcDir 'src/main/libs'
+        // This is not necessary unless you have precompiled libraries in your project.
     }
 
     buildTypes {
@@ -83,7 +84,7 @@ android {
         // abortOnError false
     }
 
-    dexOptions{
+    dexOptions {
         jumboMode = true
     }
 
@@ -131,116 +132,110 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    // App dependencies
-    implementation "androidx.appcompat:appcompat:$appCompatVersion"
-    implementation "androidx.cardview:cardview:$cardViewVersion"
-    implementation "com.google.android.material:material:$materialVersion"
-    implementation "androidx.recyclerview:recyclerview:$recyclerViewVersion"
+// Desugaring
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.10'
+
+// Kotlin
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
-    implementation "androidx.legacy:legacy-support-$legacySupportVersion"
-    implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
-    implementation "androidx.viewpager2:viewpager2:$viewPagerVersion"
-    implementation "com.google.code.gson:gson:$gsonVersion"
 
-    // Architecture Components
-    implementation "androidx.fragment:fragment-ktx:$fragmentKtxVersion"
-
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
-    implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion"
-    implementation "androidx.lifecycle:lifecycle-reactivestreams-ktx:$lifecycleVersion"
+// AndroidX
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.cardview:cardview:1.0.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.3'
+    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation 'androidx.emoji:emoji-appcompat:1.1.0'
+    implementation 'androidx.exifinterface:exifinterface:1.3.0'
+    implementation 'androidx.fragment:fragment-ktx:1.2.5'
+    implementation 'androidx.multidex:multidex:2.0.1'
     implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-process:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-reactivestreams-ktx:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-service:$lifecycleVersion"
-
-    implementation "androidx.navigation:navigation-runtime-ktx:$navigationVersion"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
     implementation "androidx.navigation:navigation-fragment-ktx:$navigationVersion"
+    implementation "androidx.navigation:navigation-runtime-ktx:$navigationVersion"
     implementation "androidx.navigation:navigation-ui-ktx:$navigationVersion"
+    implementation 'androidx.palette:palette-ktx:1.0.0'
+    implementation 'androidx.preference:preference-ktx:1.1.1'
+    implementation 'androidx.recyclerview:recyclerview:1.1.0'
+    implementation 'androidx.viewpager2:viewpager2:1.0.0'
+    implementation 'com.google.android.material:material:1.3.0'
 
-    // Kotlin
-    implementation "androidx.core:core-ktx:$ktxVersion"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-
+// Third-party
     // Hilt
     implementation "com.google.dagger:hilt-android:$hiltVersion"
     kapt "com.google.dagger:hilt-android-compiler:$hiltVersion"
     implementation "androidx.hilt:hilt-lifecycle-viewmodel:$hiltAndroidXVersion"
     kapt "androidx.hilt:hilt-compiler:$hiltAndroidXVersion"
 
-    // Other libs
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.exifinterface:exifinterface:1.3.0'
-    implementation 'androidx.recyclerview:recyclerview:1.1.0'
+    // ExoPlayer
+    implementation "com.google.android.exoplayer:exoplayer-core:$exoplayerVersion"
+    implementation "com.google.android.exoplayer:exoplayer-ui:$exoplayerVersion"
+    implementation(name: "exoplayer-extension-ffmpeg-$exoplayerVersion", ext: 'aar')
+    implementation(name: "exoplayer-extension-flac-$exoplayerVersion", ext: 'aar')
+
+    // Other
+    implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.github.nirhart:parallaxscroll:1.0'
-    implementation 'androidx.palette:palette-ktx:1.0.0'
-    implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'com.vdurmont:emoji-java:4.0.0'
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.12.1'
-    implementation 'com.google.android.exoplayer:exoplayer-ui:2.12.1'
-    implementation(name: 'exoplayer-extension-ffmpeg-2.12.1', ext: 'aar')
-    implementation(name: 'exoplayer-extension-flac-2.12.1', ext: 'aar')
     implementation 'com.google.zxing:core:3.4.0'
     implementation 'com.budiyev.android:code-scanner:1.8.3'
     implementation 'me.leolin:ShortcutBadger:1.1.22@aar'
     implementation 'com.brandongogetap:stickyheaders:0.6.1'
     implementation 'com.github.ittianyu:BottomNavigationViewEx:2.0.4'
-    implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'androidx.emoji:emoji-appcompat:1.1.0'
-    implementation 'androidx.preference:preference-ktx:1.1.1'
     implementation 'io.supercharge:shimmerlayout:2.1.0'
     implementation 'net.opacapp:multiline-collapsingtoolbar:27.1.1'
     implementation 'com.github.tony19:named-regexp:0.2.5'
     implementation 'org.hamcrest:hamcrest-library:1.3'
-    implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.google.android:flexbox:2.0.1'
     implementation 'jp.wasabeef:blurry:2.1.0'
     implementation 'com.github.meganz.AndroidDocumentScanner:documentscanner:2.0.8'
+    implementation 'org.jetbrains.anko:anko-commons:0.10.8'
+    implementation 'com.github.zhpanvip:BannerViewPager:3.4.0'
+    implementation 'com.jeremyliao:live-event-bus-x:1.7.3'
 
-    implementation "io.reactivex.rxjava3:rxjava:$rxJavaVersion"
-    implementation "io.reactivex.rxjava3:rxandroid:$rxAndroidVersion"
-    implementation "io.reactivex.rxjava3:rxkotlin:3.0.1"
-    implementation "org.jetbrains.anko:anko-commons:$ankoVersion"
+    // ReactiveX
+    implementation 'io.reactivex.rxjava3:rxandroid:3.0.0'
+    implementation 'io.reactivex.rxjava3:rxjava:3.0.4'
+    implementation 'io.reactivex.rxjava3:rxkotlin:3.0.1'
 
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.10'
-
+    // Fresco
     implementation "com.facebook.fresco:fresco:$frescoVersion"
     implementation "com.facebook.fresco:animated-gif:$frescoVersion"
     implementation "com.facebook.fresco:animated-webp:$frescoVersion"
     implementation "com.facebook.fresco:webpsupport:$frescoVersion"
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
-
-    implementation "com.github.zhpanvip:BannerViewPager:$bannerViewPagerVersion"
-
-    implementation "org.jetbrains.anko:anko-commons:$ankoVersion"
-
-    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
-    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    // Retrofit
+    implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
+    implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
     implementation files('src/main/libs/libwebrtc.jar')
 
-    implementation "com.jeremyliao:live-event-bus-x:$liveEventBus"
+    // Play Core
+    implementation 'com.google.android.play:core:1.10.0'
+    implementation 'com.google.android.play:core-ktx:1.8.1'
 
+// Build flavors
     //GMS
+    gmsImplementation 'com.google.firebase:firebase-analytics-ktx'
     gmsImplementation 'com.google.firebase:firebase-core:18.0.0'
+    gmsImplementation 'com.google.firebase:firebase-crashlytics-ndk'
     gmsImplementation 'com.google.firebase:firebase-messaging:21.0.1'
     gmsImplementation 'com.android.billingclient:billing:3.0.2'
+    gmsImplementation 'com.google.android.gms:play-services-ads:19.7.0'
     gmsImplementation 'com.google.android.gms:play-services-location:17.1.0'
     gmsImplementation 'com.google.android.gms:play-services-maps:17.0.0'
     gmsImplementation 'com.google.maps.android:android-maps-utils:0.5'
-    gmsImplementation "com.google.android.gms:play-services-ads:$playServicesAdsVersion"
-    gmsImplementation platform("com.google.firebase:firebase-bom:$firebaseBom")
-    gmsImplementation 'com.google.firebase:firebase-crashlytics-ndk'
-    gmsImplementation 'com.google.firebase:firebase-analytics-ktx'
+    gmsImplementation platform('com.google.firebase:firebase-bom:26.7.0')
+
     //HMS
-    hmsImplementation 'com.huawei.hms:push:4.0.2.300'
+    hmsImplementation 'com.huawei.hms:iap:4.0.2.300'
     hmsImplementation 'com.huawei.hms:location:4.0.2.300'
     hmsImplementation 'com.huawei.hms:maps:4.0.1.301'
-    hmsImplementation 'com.huawei.hms:iap:4.0.2.300'
-
-    // Play Core
-    implementation("com.google.android.play:core:1.10.0")
-    implementation("com.google.android.play:core-ktx:1.8.1")
+    hmsImplementation 'com.huawei.hms:push:4.0.2.300'
 }
 
 def taskRequests = gradle.getStartParameter().getTaskRequests().toString()

--- a/build.gradle
+++ b/build.gradle
@@ -52,35 +52,21 @@ ext {
     appVersion = "4.2.1"
     versionCode = 393
 
-    // Sdk and tools
+    // SDK and tools
     compileSdkVersion = 29
     minSdkVersion = 21
     targetSdkVersion = 29
     buildToolsVerion = '29.0.3'
 
-    // App dependencies
-    appCompatVersion = '1.2.0'
-    daggerVersion = "2.24"
-    constraintLayoutVersion = '2.0.3'
+    // Kotlin
     coroutinesVersion = "1.4.1"
-    fragmentKtxVersion = '1.2.5'
-    glideVersion = '4.10.0'
-    gsonVersion = '2.8.5'
-    ktxVersion = '1.3.2'
+
+    // AndroidX
     lifecycleVersion = '2.3.0'
-    materialVersion = '1.3.0'
-    recyclerViewVersion = '1.1.0'
-    roomVersion = '2.2.5'
-    viewPagerVersion = '1.0.0'
-    cardViewVersion = '1.0.0'
-    legacySupportVersion = 'v4:1.0.0'
+
+    // Third-party
     hiltAndroidXVersion = '1.0.0-alpha02'
-    rxJavaVersion = '3.0.4'
-    rxAndroidVersion = '3.0.0'
-    ankoVersion = '0.10.8'
+    exoplayerVersion = '2.12.1'
     frescoVersion = '2.3.0'
-    playServicesAdsVersion = '19.7.0'
-    bannerViewPagerVersion = '3.4.0'
-    liveEventBus = '1.7.3'
-    firebaseBom = '26.7.0'
+    retrofitVersion = '2.9.0'
 }


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
- This rearranges the libraries to be more readable.
- Consequently, this also cleans up duplicates where libraries were defined more than once in random spots.
- Finally, deleted some unused libraries (e.g. lifecycle-extensions, androidx-legacy, glide version in ext, etc.)

## Does this solve any currently open issues?
No.

## Any relevant logs, error output, etc?
No.

## Any other comments?
No.

## Where has this been tested?
No tests necessary.
